### PR TITLE
{member_id} does not parse in a template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
 ee-raw-member-field
 ===================
 
-A plugin for ExpressionEngine that returns data from member fields without the automatic formatting imposed by the standard exp:member:custom_profile_data template variables
+A plugin for ExpressionEngine that returns data from member fields without the automatic formatting imposed by the standard exp:member:custom_profile_data template variables.
+
+Usage:
+
+{exp:raw_member_field field_name="Google_Plus_URL"}
+
+Installation:
+
+Copy the raw_member_field folder to the third-party plugins folder. Its automatically enabled.

--- a/raw_member_field/pi.raw_member_field.php
+++ b/raw_member_field/pi.raw_member_field.php
@@ -61,8 +61,8 @@ class Raw_member_field {
 	    $this->EE =& get_instance();
       
       $memberFieldName = $this->EE->TMPL->fetch_param('field_name') ? $this->EE->TMPL->fetch_param('field_name') : '';
-      $memberId = $this->EE->TMPL->fetch_param('member_id') ? $this->EE->TMPL->fetch_param('member_id') : '';
-      
+      $memberId = ee()->session->userdata('member_id');
+
       if (!$memberFieldName || !$memberId) return;
       
       $fieldId = $this->EE->db->select('m_field_id')
@@ -100,10 +100,10 @@ class Raw_member_field {
 		
 		ob_start(); 
 		?>
-    This plugin will query the database for the value of a member data field
-    based on the field_name and member_id supplied.
+    This plugin will query the database for the value of the logged in member data field
+    based on the field_name supplied.
 		
-		{exp:raw_member_field field_name="Google_Plus_URL" member_id="{member_id}"}
+		{exp:raw_member_field field_name="Google_Plus_URL"}
 	
     Version 1.0
     ******************


### PR DESCRIPTION
EE.2.9.2 does not parse the {member_id} in  {exp:raw_member_field field_name="custom_email" member_id="{member_id}"}

Instead, replaced $memberId with a session variable. Ends up with shorter code in template with one less parameter.

So its now {exp:raw_member_field field_name="custom_email"}
